### PR TITLE
Adding path specification as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Using the Repo Source
 
 ```hcl
-github.com/pbs/terraform-aws-iam-role-module?ref=0.1.23
+github.com/pbs/terraform-aws-iam-role-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -26,7 +26,7 @@ Integrate this module like so:
 
 ```hcl
 module "role" {
-  source = "github.com/pbs/terraform-aws-iam-role-module?ref=0.1.23"
+  source = "github.com/pbs/terraform-aws-iam-role-module?ref=x.y.z"
 
   policy_json = data.aws_iam_policy_document.policy_document.json
 
@@ -45,7 +45,7 @@ module "role" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.1.23`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -98,6 +98,7 @@ No modules.
 | <a name="input_aws_services"></a> [aws\_services](#input\_aws\_services) | AWS services that will be assuming this role. e.g. [lambda, edgelambda] | `set(string)` | `[]` | no |
 | <a name="input_create_instance_profile"></a> [create\_instance\_profile](#input\_create\_instance\_profile) | Create an instance profile for this role | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name of the IAM role. If use\_prefix is true, this will be the prefix of the role name. If null, will default to `product` value. | `string` | `null` | no |
+| <a name="input_path"></a> [path](#input\_path) | Path to the role | `string` | `null` | no |
 | <a name="input_permissions_boundary_arn"></a> [permissions\_boundary\_arn](#input\_permissions\_boundary\_arn) | ARN of the permissions boundary to use for this role | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Extra tags | `map(string)` | `{}` | no |
 | <a name="input_use_prefix"></a> [use\_prefix](#input\_use\_prefix) | Use prefix instead of explicit name | `bool` | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ resource "aws_iam_role" "role" {
   name_prefix          = local.role_prefix
   assume_role_policy   = local.assume_role_policy
   permissions_boundary = var.permissions_boundary_arn
+  path                 = var.path
 
   tags = local.tags
 }

--- a/optional.tf
+++ b/optional.tf
@@ -34,3 +34,9 @@ variable "permissions_boundary_arn" {
   default     = null
   type        = string
 }
+
+variable "path" {
+  description = "Path to the role"
+  default     = null
+  type        = string
+}


### PR DESCRIPTION
Adds the ability to specify a [path](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html) for the role created by this module.