### PR TITLE
Add role name to module outputs

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.24.0"
   constraints = ">= 4.5.0"
   hashes = [
+    "h1:5kF6+4jUPI73O/uDvm/8/NiKRhiaOqMTqdo5l8uAygo=",
     "h1:tAteY6hnPFlxGx88cjNXQT3x5Of6lz0EUaZTn3wsjUA=",
     "zh:164b4ac71c9fc6b991021dd6e829591b0c1a0ebfb5831da0a7eb4f10f92c76a7",
     "zh:22e85772a1767498796f160b54a156db8173c4e238469dad8328a65093e033e1",

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ### Using the Repo Source
 
 ```hcl
-github.com/pbs/terraform-aws-iam-role-module?ref=0.2.2
+github.com/pbs/terraform-aws-iam-role-module?ref=x.y.z
 ```
 
 ### Alternative Installation Methods
@@ -26,7 +26,7 @@ Integrate this module like so:
 
 ```hcl
 module "role" {
-  source = "github.com/pbs/terraform-aws-iam-role-module?ref=0.2.2"
+  source = "github.com/pbs/terraform-aws-iam-role-module?ref=x.y.z"
 
   policy_json = data.aws_iam_policy_document.policy_document.json
 
@@ -45,7 +45,7 @@ module "role" {
 
 If this repo is added as a subtree, then the version of the module should be close to the version shown here:
 
-`0.2.2`
+`x.y.z`
 
 Note, however that subtrees can be altered as desired within repositories.
 
@@ -108,3 +108,4 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the IAM role |
+| <a name="output_name"></a> [name](#output\_name) | Name of the IAM role |

--- a/outputs.tf
+++ b/outputs.tf
@@ -2,3 +2,8 @@ output "arn" {
   description = "ARN of the IAM role"
   value       = aws_iam_role.role.arn
 }
+
+output "name" {
+  description = "Name of the IAM role"
+  value       = aws_iam_role.role.name
+}


### PR DESCRIPTION
This will allow consumers of the module to use the role instance with role policy attachments, which will, in turn, allow for expanding the permissions granted initially to the role. Normally, this would be done by simply adjusting the policy of the role itself, but if the role is consumed by another module (as is often the case), then that is relatively infeasible.

Role policy attachments and AWS IAM role data sources accept a role name as a reference to an existing role, not an ARN.
